### PR TITLE
Fix format video et filter

### DIFF
--- a/resources/lib/TouTvPlayer.py
+++ b/resources/lib/TouTvPlayer.py
@@ -1,6 +1,7 @@
 ﻿
 import os
 import sys
+import re
 import xbmc
 import xbmcgui
 import scraper
@@ -97,9 +98,9 @@ def playVideoExtra( PID, pKEY, startoffset=None, listitem_in=None ):
         PROTOCOL = 'mpd'
         DRM = 'com.widevine.alpha'
         BEARER  = data['widevineAuthToken']
-        url = data['url']
-        url = url.replace('(filter=2000)','(filter=3000)')
-        url = url.replace('(filter=3000)', '(filter=3000,format=mpd-time-csf)')
+
+        # Force filter 7000 et le bon format
+        url = re.sub(r'\(filter=\d+\)', '(filter=7000,format=mpd-time-csf)', data['url'])
         
         is_helper = inputstreamhelper.Helper(PROTOCOL, drm=DRM)
         if is_helper.check_inputstream():


### PR DESCRIPTION
La majorite des emissinons fonctionnaient plus puisque le format video n'etait plus specifie (format=mpd-time-csf). Le format n'etait specifie que si le filter etait de 2000 ou 3000. Or maintenant tous les streams semblent etre sur le 7000.

Alors petit regex pour capturer n'importe quel filter et forcer le 7000 avec le format.