### PR TITLE
Lecture de la source audio sans video description par defaut

### DIFF
--- a/resources/lib/TouTvPlayer.py
+++ b/resources/lib/TouTvPlayer.py
@@ -172,6 +172,13 @@ class XBMCPlayer(xbmc.Player):
         self.is_active = True
         print "#XBMCPlayer#"
     
+    def onAVStarted( self ):
+        # Force la derniere source audio pour eviter la video description
+        # Generalement 2 sources:
+        #   0 => video description, 
+        #   1 => original
+        self.setAudioStream(len(self.getAvailableAudioStreams()) - 1)
+
     def onPlayBackPaused( self ):
         xbmc.log("#Im paused#")
         print self.getTime()


### PR DESCRIPTION
Beaucoup d'emissions ont deux sources audio une avec video description et une sans. Par defaut, la source audio est celle avec la video description.  Maintenant, la derniere source audio est utilise (devrait etre celle sans video description).