### PR TITLE
Enlever les références pour FancyURLopener

### DIFF
--- a/resources/lib/toutvapiservice.py
+++ b/resources/lib/toutvapiservice.py
@@ -14,6 +14,7 @@ if sys.version_info.major >= 3:
     # Python 3 stuff
     from urllib.parse import quote_plus, unquote_plus, urlencode
     import urllib.parse
+    from urllib.request import build_opener, HTTPCookieProcessor, HTTPHandler, Request, urlopen
     from io import StringIO as StringIO 
     import http.cookiejar as cookielib
 else:

--- a/resources/lib/toutvapiservice.py
+++ b/resources/lib/toutvapiservice.py
@@ -14,7 +14,6 @@ if sys.version_info.major >= 3:
     # Python 3 stuff
     from urllib.parse import quote_plus, unquote_plus, urlencode
     import urllib.parse
-    from urllib.request import FancyURLopener, build_opener, HTTPCookieProcessor, HTTPHandler, Request, urlopen
     from io import StringIO as StringIO 
     import http.cookiejar as cookielib
 else:
@@ -485,11 +484,6 @@ def get_html_source( url, refresh=False, uselocal=False ):
     except:
         print_exc()
     return source
-
-
-class _urlopener( FancyURLopener ):
-    version = os.environ.get( "HTTP_USER_AGENT" ) or HTTP_USER_AGENT
-_urlopener = _urlopener()
 
 
 class TouTvApi:


### PR DESCRIPTION
Fix pour #36 

J'ai enlevé les références pour FancyURLopener qui n'est plus supporté dans python 3.14, présent dans Kodi 22.  En gros, FancyURLopener était importé pour python 3 (je l'ai enlevé) et pour python 2 (je n'y ai pas touché, mais j'imagine qu'il ne sert plus là non plus).

FaancyURLopener était ensuite utilisé pour faire une classe `_urlopener` mais pour laquelle je n'ai trouvé aucune référence dans le reste du code.  J'imagine donc que c'est une relique et que ça ne sert plus.  Je l'ai simplement effacé.  

J'ai testé mon code sur kodi - CoreElec - v22 et ça marche.  J'imagine que tu peux inclure ce fix au code original, mais sache que j'ai très peu testé (juste une plateforme et juste un stream).

C'est mon premier pull request à vie, je ne sais pas si j'ai bien fait ça mais j'espère que oui.  Si non, je m'en excuse et j'essayerai de faire mieux la prochaine fois!

Merci pour le super add-on. 
